### PR TITLE
Implement 'Mark this node temporarily offline' for host slave

### DIFF
--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopCloud.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopCloud.java
@@ -74,6 +74,10 @@ public final class ParallelsDesktopCloud extends Cloud
 		LOGGER.log(Level.SEVERE, "Going to provision %d executors", excessWorkload);
 		Collection<NodeProvisioner.PlannedNode> result = new ArrayList<NodeProvisioner.PlannedNode>();
 		final ParallelsDesktopConnectorSlaveComputer connector = getConnector();
+		if (connector.isOffline())
+		{
+			return result;
+		}
 		for (int i = 0; (i < vms.size()) && (excessWorkload > 0); i++)
 		{
 			final ParallelsDesktopVM vm = vms.get(i);

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopConnectorSlave.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopConnectorSlave.java
@@ -57,6 +57,11 @@ public class ParallelsDesktopConnectorSlave extends AbstractCloudSlave implement
 		this.useAsBuilder = useAsBuilder;
 	}
 
+	public ParallelsDesktopCloud getOwner()
+	{
+		return owner;
+	}
+
 	@Override
 	public AbstractCloudComputer createComputer()
 	{

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlaveComputer.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlaveComputer.java
@@ -47,7 +47,7 @@ public class ParallelsDesktopVMSlaveComputer extends AbstractCloudComputer<Paral
 	@Override
 	public boolean hasPermission(Permission permission)
 	{
-		if (permission == CONFIGURE)
+		if (permission == CONFIGURE || permission == DISCONNECT || permission == CONNECT)
 			return false;
 		return super.hasPermission(permission);
 	}


### PR DESCRIPTION
Do not provision VM slaves when the host slave is offline. Put all VM slaves offline when the host slave is put offline. Update cloud slaves offline reason with the host slave offline reason.