### PR TITLE
Run tasks on Parallels Desktop host and its VMs exclusively. Fix host slave usage configuration

### DIFF
--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopNodeProperties.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopNodeProperties.java
@@ -1,0 +1,11 @@
+package com.parallels.desktopcloud;
+
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
+
+public class ParallelsDesktopNodeProperties extends DescribableList<NodeProperty<?>, NodePropertyDescriptor> {
+
+	public ParallelsDesktopNodeProperties() {
+	}
+}

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
@@ -65,13 +65,13 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	private final String remoteFS;
 	private transient String slaveName;
 	private final ComputerLauncher launcher;
-	private List<NodeProperty<?>> nodeProperties;
+	private ParallelsDesktopNodeProperties nodeProperties;
 	private transient boolean provisioned = false;
 	private PostBuildBehaviors postBuildBehavior;
 	private transient VMStates prevVmState;
 
 	@DataBoundConstructor
-	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, List<NodeProperty<?>> nodeProperties)
+	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, ParallelsDesktopNodeProperties nodeProperties)
 	{
 		this.vmid = vmid;
 		this.labels = labels;
@@ -121,12 +121,12 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 		return slaveName;
 	}
 
-	public List<NodeProperty<?>> getNodeProperties()
+	public ParallelsDesktopNodeProperties getNodeProperties()
 	{
 		return nodeProperties;
 	}
 
-	public void setNodeProperties(List<NodeProperty<?>> nodeProperties)
+	public void setNodeProperties(ParallelsDesktopNodeProperties nodeProperties)
 	{
 		this.nodeProperties = nodeProperties;
 	}

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
@@ -25,11 +25,16 @@
 package com.parallels.desktopcloud;
 
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Slave;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.ListBoxModel;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -60,17 +65,19 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	private final String remoteFS;
 	private transient String slaveName;
 	private final ComputerLauncher launcher;
+	private List<NodeProperty<?>> nodeProperties;
 	private transient boolean provisioned = false;
 	private PostBuildBehaviors postBuildBehavior;
 	private transient VMStates prevVmState;
 
 	@DataBoundConstructor
-	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior)
+	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, List<NodeProperty<?>> nodeProperties)
 	{
 		this.vmid = vmid;
 		this.labels = labels;
 		this.remoteFS = remoteFS;
 		this.launcher = launcher;
+		this.nodeProperties = nodeProperties;
 		try
 		{
 			this.postBuildBehavior = PostBuildBehaviors.valueOf(postBuildBehavior);
@@ -112,6 +119,16 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	public String getSlaveName()
 	{
 		return slaveName;
+	}
+
+	public List<NodeProperty<?>> getNodeProperties()
+	{
+		return nodeProperties;
+	}
+
+	public void setNodeProperties(List<NodeProperty<?>> nodeProperties)
+	{
+		this.nodeProperties = nodeProperties;
 	}
 
 	public void setProvisioned(boolean provisioned)
@@ -242,6 +259,10 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 			m.add(Messages.Parallels_Behavior_KeepRunning(), PostBuildBehaviors.KeepRunning.name());
 			m.add(Messages.Parallels_Behavior_ReturnPrevState(), PostBuildBehaviors.ReturnPrevState.name());
 			return m;
+		}
+
+		public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
+			return Functions.getNodePropertyDescriptors(Slave.class);
 		}
 	}
 }

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
@@ -29,7 +29,6 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.model.Node.Mode;
-import hudson.slaves.NodeProperty;
 import hudson.Extension;
 import hudson.model.Node;
 import hudson.slaves.EphemeralNode;
@@ -50,7 +49,7 @@ public class ParallelsDesktopVMSlave extends AbstractCloudSlave implements Ephem
 			throws IOException, Descriptor.FormException
 	{
 		super(vm.getSlaveName(), "", vm.getRemoteFS(), 1, Mode.NORMAL, vm.getLabels(), vm.getLauncher(),
-				new ParallelsDesktopCloudRetentionStrategy(), new ArrayList<NodeProperty<?>>());
+				new ParallelsDesktopCloudRetentionStrategy(), vm.getNodeProperties());
 		this.connector = connector;
 		this.vm = vm;
 	}

--- a/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
+++ b/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
@@ -61,4 +61,6 @@ THE SOFTWARE.
 			</f:dropdownListBlock>
 		</j:forEach>
 	</f:dropdownList>
+
+	<f:descriptorList title="${%Node Properties}" descriptors="${descriptor.getNodePropertyDescriptors()}" field="nodeProperties" />
 </j:jelly>


### PR DESCRIPTION
Implement a simple strategy of sharing Parallels Desktop host slave resources:
- Do not provision Parallels Desktop VM slaves when there're tasks running on the host slave,
- Programmatically suspend the host when there're running VM slaves that need to be stopped.


useAsBuilder flag in Parallels Desktop Cloud configuration is confusing. Replace useAsBuilder implementation from 89a59cd with a standard, library implementation used for all slaves. It does exactly the same thing under the hood.