### PR TITLE
Implement node properties for Parallels Desktop Cloud slaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 With the Jenkins plugin, Parallels Desktop virtual machines are launched dynamically whenever they are needed to build jobs, and then suspended during idle time, for high-density usage of resources.
 
-If you develop cross-platform software that targets OS X and iOS, then you probably know you can't run OS X virtual machines on regular PC hardware. For continuous integration, you have to use Mac computers in your setup. With this plugin you can run all your builds on a single "homogeneous" setup and worry less about the infrastructure.
+If you develop cross-platform software that targets macOS and iOS, then you probably know you can't run macOS virtual machines on regular PC hardware. For continuous integration, you have to use Mac computers in your setup. With this plugin, you can run all your builds on a single "homogeneous" setup and worry less about the infrastructure.
 
 Guest OS support:
-* OS X 10.6 and above
-* Windows 2000 SP3 and above
-* CentOS 5, Debian 7, Ubuntu 10.04 and above
+* macOS (Intel-based - supported; Apple Silicon - in testing)
+* Windows
+* Linux
+  (https://www.parallels.com/eu/products/desktop/resources/#requirements provides details on the supported versions and distributives)
 
 Requirements:
-* [Jenkins LTS](https://jenkins-ci.org/changelog-stable), 1.609.2 or later. Previous versions may work, but are not tested
-* [Parallels Desktop 11](http://www.parallels.com/products/desktop/) Pro or Business edition
+* [Jenkins LTS](https://jenkins-ci.org/changelog-stable), 1.609.2 or later.
+* [Parallels Desktop for Mac](https://www.parallels.com/products/desktop/pro/) Pro or Business edition
 
 ## Installation ##
 
@@ -25,15 +26,15 @@ To do so:
 
 ## Configuration ##
 
-First you must configure a host machine on which Parallels Desktop is installed. Enable "Remote Login" in OS X "Sharing" settings to allow incoming SSH connections.
+First, you must configure a host machine on which Parallels Desktop is installed. Enable "Remote Login" in macOS "Sharing" settings to allow incoming SSH connections.
 
-Then make sure that you have Java 1.7.0 or greater on your virtual machines. Otherwise Jenkins will be unable to start slaves on them.
+Then make sure that you have Java 1.7.0 or greater on your virtual machines. Otherwise, Jenkins will be unable to start slaves on them.
 
 ### Cloud Configuration ###
 
 * Go to Manage Jenkins->Configure System.
 * Scroll down to the "Cloud" Section and click "Add a new cloud".
-* Then configure the connection to the host with Parallels Desktop (substitute host name and other parameters as appropriate).
+* Then configure the connection to the host with Parallels Desktop (substitute hostname and other parameters as appropriate).
 
 ![alt tag](https://raw.githubusercontent.com/Parallels/jenkins-parallels/master/src/main/resources/cloud_config.png?token=AGasieKI4XsJMblErXOWrlR2n7QOlyzxks5V3HPqwA%3D%3D)
 
@@ -41,16 +42,16 @@ Then make sure that you have Java 1.7.0 or greater on your virtual machines. Oth
 
 * In the same "Cloud" section, under "Virtual Machines" click "Add".
 * In Virtual Machine ID you can either specify the VM name or UUID (which you can find from Terminal by entering "prlctl list -a").
-* Fill in the rest of config as you would for the regular slave, but skip "Host", since it will be configured dynamically.
+* Fill in the rest of the config as you would for the regular slave, but skip "Host", since it will be configured dynamically.
 * Specify Labels that you will bind "cloud" jobs to.
 
 ![alt tag](https://raw.githubusercontent.com/Parallels/jenkins-parallels/master/src/main/resources/slave_config.png?token=AGasiSnBRAeyZgiq8VkF3CSicTs97cfyks5V3HPFwA%3D%3D)
 
 ## Usage ##
 
-Now in any of the build jobs you can set Labels to one of those you configured in your VMs during the Slave Configuration step.
+Now in any of the build jobs, you can set Labels to one of those you configured in your VMs during the Slave Configuration step.
 
-When your job is scheduled and there are not enough executors to perform the build, the plugin will find a suitable virtual machine, start it, and use it to build the job. Then after approximately 1 minute of inactivity the VM will be stopped.
+When your job is scheduled and there are not enough executors to perform the build, the plugin will find a suitable virtual machine, start it, and use it to build the job. Then after approximately 1 minute of inactivity, the VM will be stopped.
 
 ## FAQ/Troubleshooting ##
 
@@ -58,7 +59,7 @@ Q: The "Host" field in the Cloud configuration goes blank after I save and re-op
 
 A: This is a known problem that we are working on. In the meantime, your changes are being saved properly, but just not being displayed.
 
-## Bugs, Pull Requests and Contacts ##
+## Bugs, Pull Requests, and Contacts ##
 
 Feel free to file bugs or change requests here:
 https://github.com/Parallels/jenkins-parallels

--- a/pom.xml
+++ b/pom.xml
@@ -62,13 +62,13 @@ THE SOFTWARE.
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>repo.jenkins-ci.org</id>
-			<url>http://repo.jenkins-ci.org/public/</url>
+			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 </project>

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopNodeProperties.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopNodeProperties.java
@@ -1,0 +1,11 @@
+package com.parallels.desktopcloud;
+
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
+
+public class ParallelsDesktopNodeProperties extends DescribableList<NodeProperty<?>, NodePropertyDescriptor> {
+
+	public ParallelsDesktopNodeProperties() {
+	}
+}

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
@@ -65,13 +65,13 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	private final String remoteFS;
 	private transient String slaveName;
 	private final ComputerLauncher launcher;
-	private List<NodeProperty<?>> nodeProperties;
+	private ParallelsDesktopNodeProperties nodeProperties;
 	private transient boolean provisioned = false;
 	private PostBuildBehaviors postBuildBehavior;
 	private transient VMStates prevVmState;
 
 	@DataBoundConstructor
-	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, List<NodeProperty<?>> nodeProperties)
+	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, ParallelsDesktopNodeProperties nodeProperties)
 	{
 		this.vmid = vmid;
 		this.labels = labels;
@@ -121,12 +121,12 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 		return slaveName;
 	}
 
-	public List<NodeProperty<?>> getNodeProperties()
+	public ParallelsDesktopNodeProperties getNodeProperties()
 	{
 		return nodeProperties;
 	}
 
-	public void setNodeProperties(List<NodeProperty<?>> nodeProperties)
+	public void setNodeProperties(ParallelsDesktopNodeProperties nodeProperties)
 	{
 		this.nodeProperties = nodeProperties;
 	}

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
@@ -25,11 +25,16 @@
 package com.parallels.desktopcloud;
 
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Slave;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.ListBoxModel;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -60,17 +65,19 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	private final String remoteFS;
 	private transient String slaveName;
 	private final ComputerLauncher launcher;
+	private List<NodeProperty<?>> nodeProperties;
 	private transient boolean provisioned = false;
 	private PostBuildBehaviors postBuildBehavior;
 	private transient VMStates prevVmState;
 
 	@DataBoundConstructor
-	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior)
+	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior, List<NodeProperty<?>> nodeProperties)
 	{
 		this.vmid = vmid;
 		this.labels = labels;
 		this.remoteFS = remoteFS;
 		this.launcher = launcher;
+		this.nodeProperties = nodeProperties;
 		try
 		{
 			this.postBuildBehavior = PostBuildBehaviors.valueOf(postBuildBehavior);
@@ -112,6 +119,16 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	public String getSlaveName()
 	{
 		return slaveName;
+	}
+
+	public List<NodeProperty<?>> getNodeProperties()
+	{
+		return nodeProperties;
+	}
+
+	public void setNodeProperties(List<NodeProperty<?>> nodeProperties)
+	{
+		this.nodeProperties = nodeProperties;
 	}
 
 	public void setProvisioned(boolean provisioned)
@@ -242,6 +259,10 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 			m.add(Messages.Parallels_Behavior_KeepRunning(), PostBuildBehaviors.KeepRunning.name());
 			m.add(Messages.Parallels_Behavior_ReturnPrevState(), PostBuildBehaviors.ReturnPrevState.name());
 			return m;
+		}
+
+		public List<NodePropertyDescriptor> getNodePropertyDescriptors() {
+			return Functions.getNodePropertyDescriptors(Slave.class);
 		}
 	}
 }

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
@@ -29,7 +29,6 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.model.Node.Mode;
-import hudson.slaves.NodeProperty;
 import hudson.Extension;
 import hudson.model.Node;
 import hudson.slaves.EphemeralNode;
@@ -50,7 +49,7 @@ public class ParallelsDesktopVMSlave extends AbstractCloudSlave implements Ephem
 			throws IOException, Descriptor.FormException
 	{
 		super(vm.getSlaveName(), "", vm.getRemoteFS(), 1, Mode.NORMAL, vm.getLabels(), vm.getLauncher(),
-				new ParallelsDesktopCloudRetentionStrategy(), new ArrayList<NodeProperty<?>>());
+				new ParallelsDesktopCloudRetentionStrategy(), vm.getNodeProperties());
 		this.connector = connector;
 		this.vm = vm;
 	}

--- a/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
+++ b/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
@@ -61,4 +61,6 @@ THE SOFTWARE.
 			</f:dropdownListBlock>
 		</j:forEach>
 	</f:dropdownList>
+
+	<f:descriptorList title="${%Node Properties}" descriptors="${descriptor.getNodePropertyDescriptors()}" field="nodeProperties" />
 </j:jelly>


### PR DESCRIPTION
Same node properties as for ordinary slaves (environment variables available to every build executed on agent, tool locations, etc).