### PR TITLE
Add run once retention strategy

### DIFF
--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopCloudRetentionStrategy.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopCloudRetentionStrategy.java
@@ -95,7 +95,7 @@ public class ParallelsDesktopCloudRetentionStrategy extends RetentionStrategy<Pa
 		@Override
 		public String getDisplayName()
 		{
-			return "ParallelsDesktop Cloud Retention Strategy";
+			return "Keep-Until-Idle Retention Strategy";
 		}
 	}
 }

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVM.java
@@ -28,8 +28,11 @@ import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.RetentionStrategy;
 import hudson.util.ListBoxModel;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -63,14 +66,17 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	private transient boolean provisioned = false;
 	private PostBuildBehaviors postBuildBehavior;
 	private transient VMStates prevVmState;
+	private RetentionStrategy<?> retentionStrategy;
 
 	@DataBoundConstructor
-	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher, String postBuildBehavior)
+	public ParallelsDesktopVM(String vmid, String labels, String remoteFS, ComputerLauncher launcher,
+		String postBuildBehavior, RetentionStrategy<?> retentionStrategy)
 	{
 		this.vmid = vmid;
 		this.labels = labels;
 		this.remoteFS = remoteFS;
 		this.launcher = launcher;
+		this.retentionStrategy = retentionStrategy;
 		try
 		{
 			this.postBuildBehavior = PostBuildBehaviors.valueOf(postBuildBehavior);
@@ -82,13 +88,14 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 		if (this.postBuildBehavior == null)
 			this.postBuildBehavior = PostBuildBehaviors.Suspend;
 		prevVmState = VMStates.Suspended;
+		// readResolve();
 	}
 
 	public String getVmid()
 	{
 		return vmid;
 	}
-	
+
 	public String getLabels()
 	{
 		return labels;
@@ -123,7 +130,7 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	{
 		return provisioned;
 	}
-	
+
 	public String getPostBuildBehavior()
 	{
 		if (postBuildBehavior == null)
@@ -135,7 +142,18 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 	{
 		return postBuildBehavior;
 	}
-	
+
+	public RetentionStrategy<?> getRetentionStrategy() {
+        return this.retentionStrategy;
+    }
+
+	protected Object readResolve() {
+		if (this.retentionStrategy == null) {
+			this.retentionStrategy = new ParallelsDesktopCloudRetentionStrategy();
+		}
+		return this;
+	}
+
 	public static VMStates parseVMState(String state)
 	{
 		if ("stopped".equals(state))
@@ -243,5 +261,12 @@ public class ParallelsDesktopVM implements Describable<ParallelsDesktopVM>
 			m.add(Messages.Parallels_Behavior_ReturnPrevState(), PostBuildBehaviors.ReturnPrevState.name());
 			return m;
 		}
+
+		public static List<Descriptor<RetentionStrategy<?>>> getRetentionStrategyDescriptors() {
+            final List<Descriptor<RetentionStrategy<?>>> result = new ArrayList<>();
+			result.add(ParallelsDesktopCloudRetentionStrategy.DESCRIPTOR);
+			result.add(ParallelsRunOnceCloudRetentionStrategy.DESCRIPTOR);
+            return result;
+        }
 	}
 }

--- a/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsDesktopVMSlave.java
@@ -50,7 +50,7 @@ public class ParallelsDesktopVMSlave extends AbstractCloudSlave implements Ephem
 			throws IOException, Descriptor.FormException
 	{
 		super(vm.getSlaveName(), "", vm.getRemoteFS(), 1, Mode.NORMAL, vm.getLabels(), vm.getLauncher(),
-				new ParallelsDesktopCloudRetentionStrategy(), new ArrayList<NodeProperty<?>>());
+				vm.getRetentionStrategy(), new ArrayList<NodeProperty<?>>());
 		this.connector = connector;
 		this.vm = vm;
 	}

--- a/src/main/java/com/parallels/desktopcloud/ParallelsRunOnceCloudRetentionStrategy.java
+++ b/src/main/java/com/parallels/desktopcloud/ParallelsRunOnceCloudRetentionStrategy.java
@@ -1,0 +1,96 @@
+package com.parallels.desktopcloud;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Executor;
+import hudson.model.ExecutorListener;
+import hudson.model.Queue;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.CloudRetentionStrategy;
+import hudson.slaves.RetentionStrategy;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ParallelsRunOnceCloudRetentionStrategy extends CloudRetentionStrategy implements ExecutorListener {
+    private static final ParallelsLogger LOGGER = ParallelsLogger.getLogger("PDCloudRetentionStrategy");
+
+    private final int idleMinutes;
+
+    @DataBoundConstructor
+    public ParallelsRunOnceCloudRetentionStrategy(int idleMinutes) {
+        super(idleMinutes);
+        this.idleMinutes = idleMinutes;
+    }
+
+    public int getIdleMinutes() {
+        return idleMinutes;
+    }
+
+    @Override
+    public void taskAccepted(final Executor executor, final Queue.Task task) {
+    }
+
+    @Override
+    public void taskCompleted(final Executor executor, final Queue.Task task, final long durationMS) {
+        taskCompleted(executor);
+    }
+
+    private void taskCompleted(final Executor executor) {
+        final AbstractCloudComputer<?> computer = (AbstractCloudComputer<?>) executor.getOwner();
+        final Queue.Executable currentExecutable = executor.getCurrentExecutable();
+        LOGGER.log(Level.FINE, "Terminating {0}.Build {1} is finished",
+                new Object[] { computer.getName(), currentExecutable });
+        taskCompleted(computer);
+    }
+
+    private void taskCompleted(final AbstractCloudComputer<?> computer) {
+        computer.setAcceptingTasks(false);
+
+        final AbstractCloudSlave computerNode = computer.getNode();
+        if (computerNode != null) {
+            try
+            {
+                computer.disconnect(null).get();
+                computerNode.terminate();
+            }
+            catch (Exception e)
+            {
+                LOGGER.log(Level.SEVERE, "Error: %s", e);
+            }
+        }
+    }
+
+    @Override
+    public void taskCompletedWithProblems(final Executor executor, final Queue.Task task, final long durationMS,
+            final Throwable problems)
+    {
+        taskCompleted(executor);
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor()
+    {
+        return DESCRIPTOR;
+    }
+
+    @Restricted(NoExternalUse.class)
+    @Extension
+    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
+
+
+    public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>>
+    {
+        @Override
+        public String getDisplayName() {
+            return "Terminate immediately after use";
+        }
+    }
+
+}

--- a/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
+++ b/src/main/resources/com/parallels/desktopcloud/ParallelsDesktopVM/config.jelly
@@ -61,4 +61,19 @@ THE SOFTWARE.
 			</f:dropdownListBlock>
 		</j:forEach>
 	</f:dropdownList>
+
+	<f:dropdownList name="retentionStrategy" title="${%Retention Strategy}">
+		<j:forEach var="d" items="${descriptor.getRetentionStrategyDescriptors()}">
+			<f:dropdownListBlock value="${d.clazz.name}" name="${d.displayName}"
+									selected="${instance.retentionStrategy!=null and d.equals(instance.retentionStrategy.descriptor)}"
+									title="${d.displayName}">
+				<j:set var="descriptor" value="${d}"/>
+				<j:set var="instance" value="${(instance.retentionStrategy!=null and d.equals(instance.retentionStrategy.descriptor)) ? instance.retentionStrategy : null}"/>
+				<f:invisibleEntry>
+						<input type="hidden" name="stapler-class" value="${d.clazz.name}"/>
+				</f:invisibleEntry>
+				<st:include from="${d}" page="${d.configPage}" optional="true"/>
+			</f:dropdownListBlock>
+		</j:forEach>
+	</f:dropdownList>
 </j:jelly>


### PR DESCRIPTION
This adds the option to terminate the agent immediately after use, this is useful in combination with the Parallels Desktop VM option `Rollback Mode`.

The original retention option has is renamed: `ParallelsDesktop Cloud Retention Strategy` -> `Keep-Until-Idle Retention Strategy`.